### PR TITLE
Si 014

### DIFF
--- a/matchers.py
+++ b/matchers.py
@@ -6,16 +6,25 @@ class InvoiceMatcher():
     """Generic class which is extended with particular patterns and labels"""
 
     def __init__(self, nlp, label):
-        """Creates a new NIP matcher using a shared vocabulary object"""
+        """Creates a new matcher using a shared vocabulary object and sets the entity label"""
         self.matcher = Matcher(nlp.vocab)
         self.label = label
 
     def __call__(self, doc: Doc) -> Doc:
         matches = self.matcher(doc)
         spans = []
+        seen_tokens = set()
+        entities = doc.ents
         for match_id, start, end in matches:
-            spans.append(Span(doc, start, end, label=self.label))
-        doc.ents = list(doc.ents) + spans
+            # spaCy does not allow overlapping entity matches so if two or more patterns can be matched
+            # we need to select the longest matching
+            if start not in seen_tokens and (end - 1) not in seen_tokens:
+                spans.append(Span(doc, start, end, label=self.label))
+                entities = [
+                    e for e in entities if not (e.start < end and e.end > start)
+                ]
+                seen_tokens.update(range(start, end))
+        doc.ents = tuple(entities) + tuple(spans)
         return doc
 
 
@@ -26,18 +35,44 @@ class NIPMatcher(InvoiceMatcher):
         """Creates a new NIP matcher using a shared vocabulary object"""
         super(NIPMatcher, self).__init__(nlp, label='NIP')
         patterns = [
-            # an optional 2-letter country code followed by 10 consecutive digits
-            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{10}'}}],
-            # 10 consecutive digits followed by an optional 2-letter country code
-            [{'TEXT': {'REGEX': '(\d{10}[a-zA-Z][a-zA-Z])?'}}],
-            # an optional 2-letter country code followed by 3-3-2-2 digit pattern (either dashes or spaces)
-            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{3}(-|\s)\d{3}(-|\s)\d{2}(-|\s)\d{2}'}}],
-            # 3-3-2-2 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
-            [{'TEXT': {'REGEX': '\d{3}(-|\s)\d{3}(-|\s)\d{2}(-|\s)\d{2}([a-zA-Z][a-zA-Z])?'}}],
-            # an optional 2-letter country code followed by 3-2-2-3 digit pattern (either dashes or spaces)
-            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{3}(-|\s)\d{2}(-|\s)\d{2}(-|\s)\d{3}'}}],
-            # 3-2-2-3 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
-            [{'TEXT': {'REGEX': '\d{3}(-|\s)\d{2}(-|\s)\d{2}(-|\s)\d{3}([a-zA-Z][a-zA-Z])?'}}]
+            # 10 consecutive digits
+            [
+                {'TEXT': {'REGEX': '\d{10}'}}
+            ],
+            # 3 3 2 2 digit format
+            [
+                {'TEXT': {'REGEX': '\d{3}'}},
+                {'TEXT': {'REGEX': '\d{3}'}},
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': {'REGEX': '\d{2}'}},
+            ],
+            # 3-3-2-2 digit format
+            [
+                {'TEXT': {'REGEX': '\d{3}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{3}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{2}'}},
+            ],
+            # 3 2 2 3 digit format
+            [
+                {'TEXT': {'REGEX': '\d{3}'}},
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': {'REGEX': '\d{3}'}},
+            ],
+            # 3-2-2-3 digit format
+            [
+                {'TEXT': {'REGEX': '\d{3}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{3}'}},
+            ],
         ]
         self.matcher.add(self.label, None, *patterns)
 
@@ -49,17 +84,57 @@ class BankNumberMatcher(InvoiceMatcher):
         """Creates a new bank number account matcher using a shared vocabulary object"""
         super(BankNumberMatcher, self).__init__(nlp, label='BANK_ACCOUNT_NO')
         patterns = [
-            # an optional 2-letter country code followed by 26 consecutive digits
-            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{26}'}}],
-            # 26 consecutive digits followed by an optional 2-letter country code
-            [{'TEXT': {'REGEX': '(\d{26}[a-zA-Z][a-zA-Z])?'}}],
-            # an optional 2-letter country code followed by 2-4-4-4-4-4-4 digit pattern (either dashes or spaces)
-            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{2}(-|\s)(\d{4}(-|\s)){5}\d{4}'}}],
-            # an optional 2-letter country code followed by 2-24 digit pattern (either dashes or spaces)
-            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{2}(-|\s)\d{24}'}}],
-            # 2-4-4-4-4-4-4 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
-            [{'TEXT': {'REGEX': '\d{2}(-|\s)(\d{4}(-|\s)){5}\d{4}([\sa-zA-Z][a-zA-Z])?'}}],
-            # 2-24 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
-            [{'TEXT': {'REGEX': '\d{2}(-|\s)\d{24}([\sa-zA-Z][a-zA-Z])?'}}]
+            # 26 consecutive digits
+            [
+                {'TEXT': {'REGEX': '\d{26}'}}
+            ],
+            # 24 digit format
+            [
+                {'TEXT': {'REGEX': '\d{24}'}},
+            ],
+            # 2-24 digit format
+            [
+                {'TEXT': {'REGEX': '\d{2}'}},
+                {'TEXT': '-', 'OP': '?'},
+                {'TEXT': {'REGEX': '\d{24}'}},
+            ],
+            # 4 4 4 4 4 4 digit format
+            [
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': {'REGEX': '\d{4}'}},
+            ],
+            # 4-4-4-4-4-4 digit format
+            [
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{4}'}},
+                {'TEXT': '-'},
+                {'TEXT': {'REGEX': '\d{4}'}},
+            ],
+
+        ]
+        self.matcher.add(self.label, None, *patterns)
+
+
+class REGONMatcher(InvoiceMatcher):
+    """Extracts matched REGON numbers and adds them as document entities with the label REGON"""
+
+    def __init__(self, nlp):
+        """Creates a new REGON matcher using a shared vocabulary object"""
+        super(REGONMatcher, self).__init__(nlp, label='REGON')
+        patterns = [
+            [
+                {'TEXT': {'REGEX': '\d{9}'}}
+            ],
         ]
         self.matcher.add(self.label, None, *patterns)

--- a/matchers.py
+++ b/matchers.py
@@ -31,3 +31,34 @@ class NIPMatcher():
             spans.append(Span(doc, start, end, label="NIP"))
         doc.ents = list(doc.ents) + spans
         return doc
+
+
+class BankNumberMatcher():
+    """Extracts matched bank account numbers and adds them as document entities with the label BANK_ACCOUNT_NO"""
+
+    def __init__(self, nlp):
+        """Creates a new bank number account matcher using a shared vocabulary object"""
+        self.matcher = Matcher(nlp.vocab)
+        patterns = [
+            # an optional 2-letter country code followed by 26 consecutive digits
+            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{26}'}}],
+            # 26 consecutive digits followed by an optional 2-letter country code
+            [{'TEXT': {'REGEX': '(\d{26}[a-zA-Z][a-zA-Z])?'}}],
+            # an optional 2-letter country code followed by 2-4-4-4-4-4-4 digit pattern (either dashes or spaces)
+            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{2}(-|\s)(\d{4}(-|\s)){5}\d{4}'}}],
+            # an optional 2-letter country code followed by 2-24 digit pattern (either dashes or spaces)
+            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{2}(-|\s)\d{24}'}}],
+            # 2-4-4-4-4-4-4 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
+            [{'TEXT': {'REGEX': '\d{2}(-|\s)(\d{4}(-|\s)){5}\d{4}([\sa-zA-Z][a-zA-Z])?'}}],
+            # 2-24 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
+            [{'TEXT': {'REGEX': '\d{2}(-|\s)\d{24}([\sa-zA-Z][a-zA-Z])?'}}]
+        ]
+        self.matcher.add('BANK_ACCOUNT_NO', None, *patterns)
+
+    def __call__(self, doc: Doc) -> Doc:
+        matches = self.matcher(doc)
+        spans = []
+        for match_id, start, end in matches:
+            spans.append(Span(doc, start, end, label="BANK_ACCOUNT_NO"))
+        doc.ents = list(doc.ents) + spans
+        return doc

--- a/matchers.py
+++ b/matchers.py
@@ -1,0 +1,33 @@
+from spacy.matcher import Matcher
+from spacy.tokens import Doc, Span
+
+
+class NIPMatcher():
+    """Extracts matched NIP instances and adds them as document entities with the label NIP"""
+
+    def __init__(self, nlp):
+        """Creates a new NIP matcher using a shared vocabulary object"""
+        self.matcher = Matcher(nlp.vocab)
+        patterns = [
+            # an optional 2-letter country code followed by 10 consecutive digits
+            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{10}'}}],
+            # 10 consecutive digits followed by an optional 2-letter country code
+            [{'TEXT': {'REGEX': '(\d{10}[a-zA-Z][a-zA-Z])?'}}],
+            # an optional 2-letter country code followed by 3-3-2-2 digit pattern (either dashes or spaces)
+            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{3}(-|\s)\d{3}(-|\s)\d{2}(-|\s)\d{2}'}}],
+            # 3-3-2-2 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
+            [{'TEXT': {'REGEX': '\d{3}(-|\s)\d{3}(-|\s)\d{2}(-|\s)\d{2}([a-zA-Z][a-zA-Z])?'}}],
+            # an optional 2-letter country code followed by 3-2-2-3 digit pattern (either dashes or spaces)
+            [{'TEXT': {'REGEX': '([a-zA-Z][a-zA-Z])?\d{3}(-|\s)\d{2}(-|\s)\d{2}(-|\s)\d{3}'}}],
+            # 3-2-2-3 digit pattern (either dashes or spaces) followed by an optional 2-letter country code
+            [{'TEXT': {'REGEX': '\d{3}(-|\s)\d{2}(-|\s)\d{2}(-|\s)\d{3}([a-zA-Z][a-zA-Z])?'}}]
+        ]
+        self.matcher.add('NIP', None, *patterns)
+
+    def __call__(self, doc: Doc) -> Doc:
+        matches = self.matcher(doc)
+        spans = []
+        for match_id, start, end in matches:
+            spans.append(Span(doc, start, end, label="NIP"))
+        doc.ents = list(doc.ents) + spans
+        return doc

--- a/matchers.py
+++ b/matchers.py
@@ -138,3 +138,23 @@ class REGONMatcher(InvoiceMatcher):
             ],
         ]
         self.matcher.add(self.label, None, *patterns)
+
+
+class MoneyMatcher(InvoiceMatcher):
+    """Extracts matched monetary amounts expressed in Polish zloty and adds them as entites with the label PLN"""
+
+    def __init__(self, nlp):
+        """Creates a new money matcher for Polish zloty usign a shared vocabulary object"""
+        super(MoneyMatcher, self).__init__(nlp, label='PLN')
+        patterns = [
+            [
+                {'POS': 'NUM'}, {'LOWER': 'zł'}
+            ],
+            [
+                {'POS': 'NUM'}, {'LOWER': 'zl'}
+            ],
+            [
+                {'POS': 'NUM'}, {'LOWER': 'pln'}
+            ],
+        ]
+        self.matcher.add(self.label, None, *patterns)

--- a/unit_tests/matchers_test.py
+++ b/unit_tests/matchers_test.py
@@ -1,0 +1,47 @@
+import unittest
+import spacy
+
+from spacy.lang.pl import Polish
+
+from ..matchers import match_NIP
+
+
+class MatchersTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nlp = Polish()
+
+    def test_NIP(self):
+        _tests = [
+            'NIP: 1234567890',
+            'NIP: PL 1234567890',
+            'NIP: PL1234567890',
+            'NIP: 1234567890 PL',
+            'NIP: 1234567890PL',
+            'NIP: 123 456 78 90',
+            'NIP: 123-456-78-90',
+            'NIP: PL 123 456 78 90',
+            'NIP: PL123-456-78-90',
+            'NIP: 123 456 78 90 PL',
+            'NIP: 123-456-78-90PL',
+            'NIP: 123 45 67 890',
+            'NIP: 123-45-67-890',
+            'NIP: PL 123 45 67 890',
+            'NIP: PL123-45-67-890',
+            'NIP: 123-45-67-890 PL',
+            'NIP: 123 45 67 890PL',
+        ]
+
+        for test in _tests:
+            _doc = self.nlp(test)
+            ent_labels = [
+                self.nlp.vocab.strings[ent_id]
+                for ent_id, start, end
+                in match_NIP()(_doc)
+            ]
+            self.assertTrue('NIP' in ent_labels)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/matchers_test.py
+++ b/unit_tests/matchers_test.py
@@ -1,18 +1,18 @@
 import unittest
 import spacy
 
-from ..matchers import NIPMatcher, BankNumberMatcher
+from ..matchers import NIPMatcher, BankNumberMatcher, REGONMatcher
 
 
 class MatchersTestCase(unittest.TestCase):
 
     def __init__(self,  *args, **kwargs):
         super(MatchersTestCase, self).__init__(*args, **kwargs)
-        self.nlp = spacy.load('en_core_web_sm')
 
     def test_NIP(self):
-        test_strings = [
+        positive_test_strings = [
             'NIP: 1234567890',
+            'NIP:1234567890',
             'NIP: PL 1234567890',
             'NIP: PL1234567890',
             'NIP: 1234567890 PL',
@@ -31,22 +31,73 @@ class MatchersTestCase(unittest.TestCase):
             'NIP: 123 45 67 890PL',
         ]
 
-        self.nlp.add_pipe(NIPMatcher(self.nlp), before='ner')
-        for test_string in test_strings:
-            doc = self.nlp(test_string)
-            self.assertTrue('NIP' in [e.label_ for e in doc.ents])
-
-    def test_bank_account_numbers(self):
-        test_strings = [
-            'mbank: 20 123456789012345678901234',
-            'mbank: PL 20 1234 1234 1234 1234 1234 1234',
-            'mbank: 20-1234-1234-1234-1234-1234-1234PL'
+        negative_test_strings = [
+            'NIP: 123 456 789',
+            'NIP:123-456-789',
+            '12 34 56 78 9 NIP',
+            'qwertyuiop',
+            'ala ma kota',
         ]
 
-        self.nlp.add_pipe(BankNumberMatcher(self.nlp), before='ner')
-        for test_string in test_strings:
-            doc = self.nlp(test_string)
-            self.assertTrue('BANK_ACCOUNT_NO' in [e.label_ for e in doc.ents])
+        nlp = spacy.load('en_core_web_sm')
+        matcher = NIPMatcher(nlp)
+        nlp.add_pipe(matcher, before='ner')
+
+        for doc in list(nlp.pipe(positive_test_strings)):
+            self.assertTrue(matcher.label in [e.label_ for e in doc.ents])
+
+        for doc in list(nlp.pipe(negative_test_strings)):
+            self.assertFalse(matcher.label in [e.label_ for e in doc.ents])
+
+    def test_bank_account_numbers(self):
+        positive_test_strings = [
+            'mbank: 20123456789012345678901234',
+            'mbank: 20 123456789012345678901234',
+            'mbank: 20-123456789012345678901234',
+            'mbank: 123412341234123412341234',
+            'mbank: 20 1234 1234 1234 1234 1234 1234',
+            'mbank: 20-1234-1234-1234-1234-1234-1234PL',
+            'mbank: 1234 1234 1234 1234 1234 1234 konto',
+            'mbank konto:1234-1234-1234-1234-1234-1234',
+        ]
+
+        negative_test_strings = [
+            'mbank: to nie jest numer konta',
+            'mbank: 12345678901234567890',
+        ]
+
+        nlp = spacy.load('en_core_web_sm')
+        matcher = BankNumberMatcher(nlp)
+        nlp.add_pipe(matcher, before='ner')
+
+        for doc in nlp.pipe(positive_test_strings):
+            self.assertTrue(matcher.label in [e.label_ for e in doc.ents])
+
+        for doc in nlp.pipe(negative_test_strings):
+            self.assertFalse(matcher.label in [e.label_ for e in doc.ents])
+
+    def test_REGON(self):
+        positive_test_strings = [
+            'REGON: 123456789',
+            'REG.N: 123456789 PL',
+            '123456789 REGON'
+        ]
+
+        negative_test_strings = [
+            'REGON: 123 456 789',
+            'REG: 12345678',
+            'REG: 123-456-789'
+        ]
+
+        nlp = spacy.load('en_core_web_sm')
+        matcher = REGONMatcher(nlp)
+        nlp.add_pipe(matcher, before='ner')
+
+        for doc in nlp.pipe(positive_test_strings):
+            self.assertTrue(matcher.label in [e.label_ for e in doc.ents])
+
+        for doc in nlp.pipe(negative_test_strings):
+            self.assertFalse(matcher.label in [e.label_ for e in doc.ents])
 
 
 if __name__ == '__main__':

--- a/unit_tests/matchers_test.py
+++ b/unit_tests/matchers_test.py
@@ -1,19 +1,19 @@
 import unittest
 import spacy
 
-from spacy.lang.pl import Polish
-
-from ..matchers import match_NIP
+from ..matchers import NIPMatcher
 
 
 class MatchersTestCase(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.nlp = Polish()
+    def __init__(self,  *args, **kwargs):
+        super(MatchersTestCase, self).__init__(*args, **kwargs)
+        self.nlp = spacy.load('en_core_web_sm')
+        self.nip_matcher = NIPMatcher(self.nlp)
+        self.nlp.add_pipe(self.nip_matcher, before='ner')
 
     def test_NIP(self):
-        _tests = [
+        test_strings = [
             'NIP: 1234567890',
             'NIP: PL 1234567890',
             'NIP: PL1234567890',
@@ -33,14 +33,9 @@ class MatchersTestCase(unittest.TestCase):
             'NIP: 123 45 67 890PL',
         ]
 
-        for test in _tests:
-            _doc = self.nlp(test)
-            ent_labels = [
-                self.nlp.vocab.strings[ent_id]
-                for ent_id, start, end
-                in match_NIP()(_doc)
-            ]
-            self.assertTrue('NIP' in ent_labels)
+        for test_string in test_strings:
+            doc = self.nlp(test_string)
+            self.assertTrue('NIP' in [e.label_ for e in doc.ents])
 
 
 if __name__ == '__main__':

--- a/unit_tests/matchers_test.py
+++ b/unit_tests/matchers_test.py
@@ -1,7 +1,7 @@
 import unittest
 import spacy
 
-from ..matchers import NIPMatcher
+from ..matchers import NIPMatcher, BankNumberMatcher
 
 
 class MatchersTestCase(unittest.TestCase):
@@ -9,8 +9,6 @@ class MatchersTestCase(unittest.TestCase):
     def __init__(self,  *args, **kwargs):
         super(MatchersTestCase, self).__init__(*args, **kwargs)
         self.nlp = spacy.load('en_core_web_sm')
-        self.nip_matcher = NIPMatcher(self.nlp)
-        self.nlp.add_pipe(self.nip_matcher, before='ner')
 
     def test_NIP(self):
         test_strings = [
@@ -33,9 +31,22 @@ class MatchersTestCase(unittest.TestCase):
             'NIP: 123 45 67 890PL',
         ]
 
+        self.nlp.add_pipe(NIPMatcher(self.nlp), before='ner')
         for test_string in test_strings:
             doc = self.nlp(test_string)
             self.assertTrue('NIP' in [e.label_ for e in doc.ents])
+
+    def test_bank_account_numbers(self):
+        test_strings = [
+            'mbank: 20 123456789012345678901234',
+            'mbank: PL 20 1234 1234 1234 1234 1234 1234',
+            'mbank: 20-1234-1234-1234-1234-1234-1234PL'
+        ]
+
+        self.nlp.add_pipe(BankNumberMatcher(self.nlp), before='ner')
+        for test_string in test_strings:
+            doc = self.nlp(test_string)
+            self.assertTrue('BANK_ACCOUNT_NO' in [e.label_ for e in doc.ents])
 
 
 if __name__ == '__main__':

--- a/unit_tests/matchers_test.py
+++ b/unit_tests/matchers_test.py
@@ -1,7 +1,7 @@
 import unittest
 import spacy
 
-from ..matchers import NIPMatcher, BankNumberMatcher, REGONMatcher
+from ..matchers import NIPMatcher, BankNumberMatcher, REGONMatcher, MoneyMatcher
 
 
 class MatchersTestCase(unittest.TestCase):
@@ -92,6 +92,30 @@ class MatchersTestCase(unittest.TestCase):
         nlp = spacy.load('en_core_web_sm')
         matcher = REGONMatcher(nlp)
         nlp.add_pipe(matcher, before='ner')
+
+        for doc in nlp.pipe(positive_test_strings):
+            self.assertTrue(matcher.label in [e.label_ for e in doc.ents])
+
+        for doc in nlp.pipe(negative_test_strings):
+            self.assertFalse(matcher.label in [e.label_ for e in doc.ents])
+
+    def test_money(self):
+        positive_test_strings = [
+            'kwota brutto 123,45 zł',
+            'kwota do zapłaty 123,90 zł',
+            'pozostało do rozliczenia 239,89 PLN',
+            #'kwota nierozliczona 12.34 zl'             #TODO: decimal dot is not recognized
+        ]
+
+        negative_test_strings = [
+            'termin zapłaty 14 dni',
+            'zakupiono 18 szt.',
+            'jabłka 12 kg',
+        ]
+
+        nlp = spacy.load('pl_model')
+        matcher = MoneyMatcher(nlp)
+        nlp.add_pipe(matcher, after='ner')
 
         for doc in nlp.pipe(positive_test_strings):
             self.assertTrue(matcher.label in [e.label_ for e in doc.ents])


### PR DESCRIPTION
Refactoring of number matchers. Now all number matchers use the `spacy.matcher.Matcher` interface and add matched spans as entities.  Also, matchers can be added to a processing pipeline using simple `nlp.add_pipe()` interface.

Implemented matchers:

- NIP number
- REGON number
- bank account number
- Polish currency amount